### PR TITLE
fix loongarch support

### DIFF
--- a/cpu_no_init.go
+++ b/cpu_no_init.go
@@ -6,6 +6,7 @@
 // +build !amd64
 // +build !amd64p32
 // +build !arm64
+// +build !loong64
 // +build !ppc64
 // +build !ppc64le
 // +build !riscv64


### PR DESCRIPTION
Fix error:

```
# github.com/templexxx/cpu
vendor/github.com/templexxx/cpu/cpu_no_init.go:16:6: doinit redeclared in this block
        vendor/github.com/templexxx/cpu/cpu_loong64.go:9:6: other declaration of doinit
```